### PR TITLE
Added email template, csv headers display, devdepency

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,10 +14,39 @@ const App = () => {
     console.log("Headers: ", headers);
   };
 
+  const handleTemplateChange = (event) => {
+    setEmailTemplate(event.target.value);
+  };
+
   return (
     <div style={{ padding: "20px" }}>
       <h1>PAW MailMerge</h1>
       <CSVUploader onDataParsed={handleDataParsed} />
+
+      {/* Divider to show available column headers from CSV*/}
+      {headers.length > 0 && (
+        <div style={{ marginTop: "20px", border: "1px solid #ccc", padding: "10px" }}>
+          <h3>Available CSV Headers for your MailMerge Template:</h3>
+          <ul>
+            {headers.map((header, index) => (
+              <li key={index}>{`{${header}}`}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/*Email Template */}
+      <div style={{ marginTop: "20px" }}>
+        <h3>Email Template:</h3>
+        <textarea
+          value={emailTemplate}
+          onChange={handleTemplateChange}
+          rows={5}
+          cols={50}
+          placeholder="Type your email template here..."
+          style={{ width: "100%", padding: "10px" }}
+        />
+      </div>
     </div>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-scripts": "^5.0.1"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "concurrently": "^9.0.1",
         "nodemon": "^3.1.7"
       }
@@ -713,9 +714,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1918,6 +1927,17 @@
         "core-js-compat": "^3.38.1",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -15319,16 +15339,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-scripts": "^5.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "concurrently": "^9.0.1",
     "nodemon": "^3.1.7"
   }


### PR DESCRIPTION
Changes:

- Added an Email Template text box on the home page, which displays the placeholder, "Type your email template here..."
- Added a divider which displays the column headers of a csv once uploaded, so a user knows which variables to use. 
- Added @babel/plugin-proposal-private-property-in-object to devDependencies to resolve a warning