### PR TITLE
Re-fixed double curly bracket issue

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,7 +20,7 @@ function App() {
       id: 1,
       name: "Greetings",
       content:
-        "Greetings {{name}}, \nHope everything is going well.\nThe following email is to...\nI look forward to your answer.\nThanks.",
+        "Greetings {name}, \nHope everything is going well.\nThe following email is to...\nI look forward to your answer.\nThanks.",
     },
   ]);
   const [selectedTemplateId, setSelectedTemplateId] = useState(1);

--- a/frontend/src/components/EmailPreview.jsx
+++ b/frontend/src/components/EmailPreview.jsx
@@ -9,7 +9,7 @@ export default function EmailPreview({ template, recipient }) {
 
     let preview = template.content;
     Object.keys(recipient).forEach((csvColumn) => {
-      const placeholder = `{{${csvColumn}}}`;
+      const placeholder = `{${csvColumn}}`;
       preview = preview.replace(new RegExp(placeholder, 'g'), recipient[csvColumn]);
     });
     return preview;

--- a/frontend/src/components/EmailTemplateEditor.jsx
+++ b/frontend/src/components/EmailTemplateEditor.jsx
@@ -32,7 +32,7 @@ const EmailTemplateEditor = ({ headers, onTemplateChange }) => {
       <textarea
         rows={5}
         cols={50}
-        placeholder="Type your email template here..., e.g., 'Hello {{firstName}} {{lastName}}, your amount due is {{amountDue}}.'"
+        placeholder="Type your email template here..., e.g., 'Hello {firstName} {lastName}, your amount due is {amountDue}.'"
         value={template}
         onChange={handleTemplateChange}
       />


### PR DESCRIPTION
I think the double curly bracket issue accidentally was re-introduced when the CSV-email logic was merged with the UI

Simple fix to resolve this, and updated the placeholder to match as well.